### PR TITLE
Removed Custom Compile Command from config.txt

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -47,4 +47,4 @@ repository=https://github.com/DaGoblin/arcade-games
 #executable=game.exe
 
 # [Optional] Specific compile command - if you have a specific compile command (eg. 'make', 'skm g++ *.cpp') - Uncomment  if required
-compile-command=skm dotnet run
+#compile-command=


### PR DESCRIPTION
Custom Compile Command in config.txt broke auto game compiling as it was skm dotnet run not skm dotnet publish. 
Removed and commented out command.